### PR TITLE
Travis: Pull `git lfs` files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ before_script:
   - python -c "import h5py as h5; print( h5.__version__ )"
 
 script:
+  # load git lfs files
+  - git lfs pull
   # build & install
   - mkdir build
   - cd build


### PR DESCRIPTION
travis should pull the `git lfs` files before it can use them in tests.

Fixes #42 (_by delivering a towel_).
