### PR TITLE
Fix for recent cmake

### DIFF
--- a/Modules/Diffractors/CrystFELPhotonDiffractor/CMakeLists.txt
+++ b/Modules/Diffractors/CrystFELPhotonDiffractor/CMakeLists.txt
@@ -2,14 +2,54 @@ INCLUDE(ExternalProject)
 
 # Make sure hdf5 and gsl are available. Want dynamic linking to hdf5.
 set (HDF5_USE_STATIC_LIBRARIES OFF)
+
 FIND_PACKAGE (HDF5 REQUIRED COMPONENTS C CXX)
 FIND_PACKAGE (GSL REQUIRED)
 
+# This macro invokes the HDF5 compiler wrapper, it parses the output and
+# extracts the path where library are stored.
+# Usage:
+# _get_h5_lib_dir(CXX VARIABLE_STORE_PATH)  
+# in case of errors the output variable is set to "NOT-FOUND"
+MACRO(_get_h5_lib_dir language output_value)
+    if (HDF5_${language}_COMPILER_EXECUTABLE)
+        EXEC_PROGRAM( ${HDF5_${language}_COMPILER_EXECUTABLE}
+                    ARGS -show
+                    OUTPUT_VARIABLE _cmp_output
+                    RETURN_VALUE _cmp_ret_val
+                    )
+        IF( ${_cmp_ret_val} EQUAL 0)
+            STRING( REGEX MATCHALL "-L([^\" ]+|\"[^\"]|\")"
+                    _lib_path_flags
+                    "${_cmp_output}")
+            FOREACH( LPATH ${_lib_path_flags})
+                STRING(REGEX REPLACE "^-L" "" LPATH ${LPATH})
+                STRING(REPLACE "//" "/" LPATH ${LPATH})
+                LIST(APPEND ${output_value} ${LPATH})
+            ENDFOREACH()
+                # ok
+        ELSE()
+            MESSAGE(INFO "Unable to determine HDF5 ${language} flags
+                    from compiler")
+                
+            SET(${output_value} "NOT-FOUND")
+        ENDIF()
+    ELSE()
+        MESSAGE(INFO "Cannot find HDF5 compuiler for language
+                ${language}")
+        SET(${output_value} "NOT-FOUND")
+    ENDIF()
+ENDMACRO()
+    
+
+_get_h5_lib_dir(CXX MYHDF5_LIBRARY_DIRS)
+_get_h5_lib_dir(C MYHDF5_LIBRARY_DIRS)
+LIST(REMOVE_DUPLICATES MYHDF5_LIBRARY_DIRS)
 # Add the project.
 ExternalProject_Add( crystfel
     URL http://www.desy.de/~twhite/crystfel/crystfel-0.6.3.tar.gz
     BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ./configure --with-hdf5=${HDF5_LIBRARY_DIRS} --disable-gtk --disable-gtk-doc --disable-png
+    CONFIGURE_COMMAND ./configure --with-hdf5=${MYHDF5_LIBRARY_DIRS} --disable-gtk --disable-gtk-doc --disable-png
     INSTALL_COMMAND ""
 )
 


### PR DESCRIPTION
Provide local macro to define and set `HDF5_LIBRARY_DIRS` disappeared from recent cmake versions. Note, in case of non-standard installations of HDF5 (e.g. libraries spread in multiple directories) the external module may not compuile correctly, but this is the previous behavior anyway.