### PR TITLE
BaseCalculator: call saveH5() when running from CLI

### DIFF
--- a/Sources/python/SimEx/Calculators/AbstractBaseCalculator.py
+++ b/Sources/python/SimEx/Calculators/AbstractBaseCalculator.py
@@ -47,6 +47,7 @@ class AbstractBaseCalculator(AbstractBaseClass, metaclass=ABCMeta):
             fname = sys.argv[1]
             calculator=cls.dumpLoader(fname)
             status = calculator._run()
+            calculator.saveH5()
             sys.exit(status)
 
     @classmethod


### PR DESCRIPTION
When running a calculator from the command line it would make sense that the `saveH5()` interface function would be called after the `backengine()` call has finished to ensure that the file formats are correct and one would not need to go back to the python objects to call this manually.