### PR TITLE
Fix data order of x and y for reading prop_out

### DIFF
--- a/Sources/python/SimEx/Calculators/XMDYNDemoPhotonMatterInteractor.py
+++ b/Sources/python/SimEx/Calculators/XMDYNDemoPhotonMatterInteractor.py
@@ -500,8 +500,9 @@ class PMIDemo(object):
         # Take central pixel values.
         sel_x = self.g_s2e['pulse']['nx'] // 2 ;
         sel_y = self.g_s2e['pulse']['ny'] // 2 ;
-        sel_pixV = self.g_s2e['pulse']['arrEver'] [sel_x,sel_y,:,:]
-        sel_pixH = self.g_s2e['pulse']['arrEhor'] [sel_x,sel_y,:,:]
+        # note: the data order in the HDF5 file is not x,y but y,x
+        sel_pixV = self.g_s2e['pulse']['arrEver'] [sel_y,sel_x,:,:]
+        sel_pixH = self.g_s2e['pulse']['arrEhor'] [sel_y,sel_x,:,:]
         dt = ( self.g_s2e['pulse']['sliceMax'] - self.g_s2e['pulse']['sliceMin'] ) / ( self.g_s2e['pulse']['nSlices'] * 1.0 )
         dx = ( self.g_s2e['pulse']['xMax'] - self.g_s2e['pulse']['xMin'] ) / ( self.g_s2e['pulse']['nx'] * 1.0 )
         dy = ( self.g_s2e['pulse']['yMax'] - self.g_s2e['pulse']['yMin'] ) / ( self.g_s2e['pulse']['ny'] * 1.0 )


### PR DESCRIPTION
The data order for x and y was switched in the reader

```python
def f_load_pulse(self, a_prop_out )
```

of the photon matter interaction module.

I loaded https://zenodo.org/record/888853 as the source file and went ahead with the `start_to_end_demo.ipynb` as mentioned in #163.

When I load the output of the pulse after propagation by hand, I can see the following
```python
import h5py
xfp  = h5py.File( "./prop_out.h5" , "r" )
nx   = xfp.get( 'params/Mesh/nx' )   .value
ny   = xfp.get( 'params/Mesh/ny' )   .value
print( nx, ny )
[Out]: 84 42
arrEver = xfp.get( 'data/arrEver' )   .value
print( arrEver.shape )
[Out]: (42, 84, 258, 2)
# order: ny, nx, nSlices, ...
```
If this is the standard behaviour then this PR will fix that. Can you confirm @CFGrote?