### PR TITLE
Fix various URLs to refer to new location

### DIFF
--- a/Docker/simex/simex_install.sh
+++ b/Docker/simex/simex_install.sh
@@ -3,7 +3,7 @@
 set -e
 
 BRANCH=develop
-URL=https://github.com/eucall-software/simex_platform/archive/${BRANCH}.zip
+URL=https://github.com/PaNOSC-ViNYL/SimEx/archive/${BRANCH}.zip
 
 cd /opt
 

--- a/Docker/simex_devel/simex_install_devel.sh
+++ b/Docker/simex_devel/simex_install_devel.sh
@@ -4,7 +4,7 @@ set -e
 
 
 BRANCH=develop
-URL=https://github.com/eucall-software/simex_platform.git
+URL=https://github.com/PaNOSC-ViNYL/SimEx.git
 cd /opt
 
 wget https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz

--- a/Sources/doc/source/include/contribute.rst
+++ b/Sources/doc/source/include/contribute.rst
@@ -1,4 +1,4 @@
 Contribute
 ----------
-- Source Code github.com/eucall-software/simex_platform
-- Issue Tracker: github.com/eucall-software/simex_platform/issues
+- Source Code https://github.com/PaNOSC-ViNYL/SimEx/
+- Issue Tracker: https://github.com/PaNOSC-ViNYL/SimEx/issues

--- a/Sources/doc/source/include/installation.rst
+++ b/Sources/doc/source/include/installation.rst
@@ -9,15 +9,15 @@ Download
 
 First obtain the source code by either cloning the repository::
 
-    $> git clone https://github.com/eucall-software/simex_platform
+    $> git clone https://github.com/PaNOSC-ViNYL/SimEx
 
 or by downloading and extracting the zip_ archive.
 
-.. _zip: https://github.com/eucall-software/simex_platform/archive/master.zip
+.. _zip: https://github.com/PaNOSC-ViNYL/SimEx/archive/master.zip
 
 After downloading (and extracting), switch into the top level directory::
 
-    $> cd simex_platform
+    $> cd SimEx
 
 Software dependencies
 `````````````````````
@@ -165,7 +165,7 @@ Make sure that the user has write access to the installation directory, or use::
 Binary packages
 _____________________
 Binary (.deb) packages are provided for Ubuntu (currently supporting version 16.04).
-https://github.com/eucall-software/simex_platform/releases/download/v0.2.0/simex-0.2.0-Ubuntu16.04.deb
+https://github.com/PaNOSC-ViNYL/SimEx/releases/download/v0.2.0/simex-0.2.0-Ubuntu16.04.deb
 
 Simply download and install, e.g. using the command (might require root privileges)::
 

--- a/Sources/python/SimEx/Utilities/shadow_to_opmd.py
+++ b/Sources/python/SimEx/Utilities/shadow_to_opmd.py
@@ -1,6 +1,6 @@
 """ :module shadow_to_opmd: Script to save a Shadow beams object to OpenPMD compliant hdf5.
     :usage: In Oasys, load this script in the Python script widget and connect the widget to the element at which to save the rays. Click "Execute". A shadow.out.h5 file should now exist in your $PWD. For OpenPMD format, please consult www.openpmd.org
-    :Neccessary adjustments: Path to the simex utility collection OpenPMD must be specified. If SimEx ist not installed, get just the class OpenPMDTools.py from https://github.com/eucall-software/simex_platform/blob/develop/Sources/python/SimEx/Utilities/OpenPMDTools.py and copy it to your working directory.
+    :Neccessary adjustments: Path to the simex utility collection OpenPMD must be specified. If SimEx ist not installed, get just the class OpenPMDTools.py from https://github.com/PaNOSC-ViNYL/SimEx/blob/develop/Sources/python/SimEx/Utilities/OpenPMDTools.py and copy it to your working directory.
     :note: Assumes that all lengths in the beam object are expressed in units of metres.
 """
 ##########################################################################


### PR DESCRIPTION
I spotted the URLs on the [installation page](https://panosc-vinyl.github.io/SimEx/#from-sources) first, then searched for `eucall-software`, but I've done manual replacements where I thought it made sense rather than a simple find & replace.