### PR TITLE
check if CrystFEL software is installed

### DIFF
--- a/Modules/Diffractors/CrystFELPhotonDiffractor/CMakeLists.txt
+++ b/Modules/Diffractors/CrystFELPhotonDiffractor/CMakeLists.txt
@@ -1,3 +1,11 @@
+find_program(HAVE_CRYSTFEL NAMES hdfsee REQUIRED)
+
+IF (HAVE_CRYSTFEL)
+    MESSAGE (">>> CrystFEL is installed!")
+    RETURN()
+ELSE ()
+    MESSAGE (">>> CrystFEL not found!")
+ENDIF()
 INCLUDE(ExternalProject)
 
 cmake_policy(SET CMP0074 NEW)


### PR DESCRIPTION
The purpose of this change is to check if `CrystFEL` software package is already installed. In this case the `SimEx` installer will just safely skip this step. This may save user from the confusion that `crystfel` is installed but `SimEx` not only fails to recognize that fact but also fails to [re]install on its own.

`make` looks for the `hdfsee` command and if it is in the `$PATH` it understands `crystfel` is installed. I admit that there might be a better way to check. I'll be delighted to see one. 

Close #238 