### PR TITLE
openPMD-api: 0.14*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ matplotlib>=1.5.1
 mpi4py
 numba
 numpy>=1.18.1
-openpmd-api~=0.13.0
+openpmd-api~=0.13.0,~=0.14.0
 periodictable>=1.4.1
 pint
 py3nvml


### PR DESCRIPTION
Adding compatibility with the 0.14.* release series of openPMD-api.
There are no breaking changes to the 0.13 releases.

Changelog:
https://openpmd-api.readthedocs.io/en/0.14.2/install/changelog.html

Upgrade Guide:
https://openpmd-api.readthedocs.io/en/0.14.2/install/upgrade.html