### PR TITLE
Docker with examples

### DIFF
--- a/Docker/simex/Dockerfile
+++ b/Docker/simex/Dockerfile
@@ -1,19 +1,21 @@
 # dsw@cloudbusting.io - Daniel Webster
 FROM chuckie82/centos_env
-LABEL maintainer="Chunhong Yoon <yoon82@stanford.edu>"
+LABEL maintainer="Carsten Fortmann-Grote carsten.grote@xfel.eu github:CFGrote dockerhub:cfgrote"
 
 ADD requirements.txt /opt/requirements.txt
 ADD python_install.sh /opt/python_install.sh
-RUN yum remove -y cmake && yum install -y cmake3 hdf5-devel flex bison   && \
+RUN yum remove -y cmake && yum install -y cmake3 hdf5-devel flex sudo  bison git   && \
     yum clean all && rm -rf /var/cache/yum                               && \
-    update-alternatives --install /usr/bin/cmake cmake /usr/bin/cmake3 3 && \
-    /opt/python_install.sh
+    update-alternatives --install /usr/bin/cmake cmake /usr/bin/cmake3 3
+ 
+RUN ["chmod", "a+x", "/opt/python_install.sh"]
+RUN "/opt/python_install.sh"
 ENV PATH /opt/miniconda/bin:$PATH
 
 ARG simex_script=simex_install.sh
 ADD $simex_script /opt/simex_install.sh
 
-RUN ["bash", "/opt/simex_install.sh"]
+RUN ["sudo", "bash", "/opt/simex_install.sh"]
 
 ENV MKLROOT=/opt/miniconda
 ENV MKL_ROOT=/opt/miniconda
@@ -25,4 +27,14 @@ ENV PYTHONPATH=$SIMEX_ROOT/Sources/python:$SIMEX_ROOT/lib/python3.7:$PYTHONPATH:
 ENV SIMEX_TESTS=$SIMEX_ROOT/Tests
 ENV PYFAI_TESTIMAGES=/tmp
 
+RUN ["pip3", "install", "jupyter"]
+
 RUN useradd -m jovyan
+
+RUN ["git", "clone", "--depth", "1", "https://github.com/PaNOSC-ViNYL/SimEx-notebooks.git", "/home/jovyan/simex_notebooks"]
+
+WORKDIR /home/jovyan/simex_notebooks
+
+CMD ["jupyter", "notebook", "--port=24306", "--no-browser", "--ip=0.0.0.0", "--allow-root"]
+
+

--- a/Docker/simex/README.md
+++ b/Docker/simex/README.md
@@ -1,0 +1,22 @@
+# Instructions for building, tagging, pushing, and running the simex docker container
+## Building
+```
+./build_image.sh
+```
+
+## Tag
+```
+docker tag simex cfgrote/simex
+```
+
+## Push
+```
+docker push cfgrote/simex
+```
+
+## Run container and start jupyter to be accessed from host or remote client on port `HOSTPORT`.
+```
+docker run -p HOSTPORT:24306 cfgrote/simex 
+```
+
+

--- a/Docker/simex/build_image
+++ b/Docker/simex/build_image
@@ -1,4 +1,4 @@
 cp ../../requirements.txt .
 
-buildah bud -t cloudbusting/simex -f Dockerfile .
+docker build -t cfgrote/simex .
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ git clone --depth 1 -b develop https://github.com/PaNOSC-ViNYL/SimEx.git
 Now the TestFiles are hosted at [Zenodo](https://zenodo.org/record/3750541#.X2R9DZMzZE5).
 The files can be downloaded with [this script](get_testdata.sh).
 
+## Docker
+Our docker image `cfgrote/simex` provides a complete runtime environment including
+* The SimEx python library
+* All dependencies and backengines
+* jupyter lab
+* Example jupyter notebooks from [simex_notebooks](https://github.com/PaNOSC-ViNYL/SimEx-notebooks). 
+  
+### Running the container
+In the terminal, run
+```
+docker run --port HOSTPORT:24306 cfgrote/simex 
+```
+If the docker image is not found on the host system, it will first be `pull`ed from dockerhub.
+
+Then, navigate to http://host:HOSTPORT and find yourself in a running jupyter notebook environment.
+
 
 ## Acknowledgements
 This project has received funding from the European Union’s Horizon 2020 research


### PR DESCRIPTION
This PR modifies the dockerfile such that now the example notebooks from https://github.com/PaNOSC-ViNYL/SimEx-notebooks are added to the image. Running the container now directly launches the jupyter notebook environment which can be accessed from the host system or any other client connecting on the specified port.